### PR TITLE
Refine LED coordinator priorities for all robot states

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -15,46 +15,25 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.util.Units;
 import frc.lib.util.COTSTalonFXSwerveConstants;
 import frc.lib.util.SwerveModuleConstants;
+import frc.robot.led.LedColor;
 
 
 public final class Constants {
     public static final double stickDeadband = 0.1;
 
     public static class LEDs {
+        public static final int CANDLE_ID = 0; // TODO: replace with actual CANdle device ID
+        public static final int LED_COUNT = 60; // TODO: replace with actual LED count
 
-        public static HashMap<String, int[]> colorDatabase = new HashMap<String, int[]>();
+        public static final double CELEBRATION_DURATION_SECONDS = 2.0;
+        public static final double CELEBRATION_PERIOD_SECONDS = 0.25;
 
-        static {
-            colorDatabase.put("Red", new int[] {255, 0, 0});
-            colorDatabase.put("Green", new int[] {0, 255, 0});
-            colorDatabase.put("Blue", new int[] {0, 0, 255});
-            colorDatabase.put("Yellow", new int[] {255, 255, 0});
-            colorDatabase.put("Purple", new int[] {255, 0, 255});
-            colorDatabase.put("Cyan", new int[] {0, 255, 255});
-            colorDatabase.put("White", new int[] {255, 255, 255});
-            colorDatabase.put("noColor", new int[] {0, 0, 0});
-        }
-        
-        public static enum LEDStates {
-            OFF(10, colorDatabase.get("noColor"));
-
-
-            
-            private final int[] color;
-            private final int priority;
-    
-            LEDStates(int priority, int[] color) {
-                            this.priority = priority;
-                            this.color = color;
-            }
-    
-            public int getPriority() {
-                return priority;
-            }
-            public int[] getColor() {
-                return color;
-            }
-        }
+        public static final LedColor TEAL = new LedColor(0, 128, 128);
+        public static final LedColor LIGHT_GREEN = new LedColor(120, 255, 150);
+        public static final LedColor DEEP_GREEN = new LedColor(0, 100, 0);
+        public static final LedColor YELLOW = new LedColor(255, 200, 0);
+        public static final LedColor PURPLE = new LedColor(160, 32, 240);
+        public static final LedColor OFF = LedColor.BLACK;
     }
 
     public static final class PieceSensors {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -86,6 +86,7 @@ public class Robot extends LoggedRobot {
   @Override
   public void disabledInit() {
     m_robotContainer.setManagerAsInactive();
+    m_robotContainer.handleDisabledInit();
   }
 
   @Override

--- a/src/main/java/frc/robot/led/LedColor.java
+++ b/src/main/java/frc/robot/led/LedColor.java
@@ -1,0 +1,27 @@
+package frc.robot.led;
+
+/**
+ * Simple RGB color wrapper used by LED patterns.
+ */
+public record LedColor(int r, int g, int b) {
+    public static final LedColor BLACK = new LedColor(0, 0, 0);
+
+    public LedColor {
+        r = clamp(r);
+        g = clamp(g);
+        b = clamp(b);
+    }
+
+    private static int clamp(int value) {
+        return Math.max(0, Math.min(255, value));
+    }
+
+    public int[] toArray() {
+        return new int[] {r, g, b};
+    }
+
+    @Override
+    public String toString() {
+        return "LedColor{" + r + "," + g + "," + b + "}";
+    }
+}

--- a/src/main/java/frc/robot/led/LedCoordinator.java
+++ b/src/main/java/frc/robot/led/LedCoordinator.java
@@ -1,0 +1,203 @@
+package frc.robot.led;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.littletonrobotics.junction.Logger;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import frc.robot.Constants;
+import frc.robot.SubsystemManager;
+import frc.robot.autoalign.ReefAutoAlign;
+import frc.robot.subsystems.LEDHandler;
+import frc.robot.superstructure.GamePieceState;
+import frc.robot.superstructure.RobotSupervisor;
+
+/**
+ * Chooses LED patterns based on robot state and forwards them to the hardware handler.
+ */
+public final class LedCoordinator {
+    private static final double FLASH_PERIOD = 0.35;
+
+    private final LEDHandler ledHandler;
+    private final RobotSupervisor supervisor;
+    private final SubsystemManager subsystemManager;
+
+    private Optional<ReefAutoAlign.AlignmentResult> alignmentResult = Optional.empty();
+    private boolean autoAlignActive = false;
+
+    private RobotSupervisor.Mode lastMode = RobotSupervisor.Mode.CORAL;
+    private double celebrationEndTimestamp = -1.0;
+    private boolean climbSettledDuringMode = false;
+    private LedPattern lastAppliedPattern;
+
+    public LedCoordinator(LEDHandler ledHandler, RobotSupervisor supervisor, SubsystemManager subsystemManager) {
+        this.ledHandler = Objects.requireNonNull(ledHandler);
+        this.supervisor = Objects.requireNonNull(supervisor);
+        this.subsystemManager = Objects.requireNonNull(subsystemManager);
+    }
+
+    public void setAlignmentResult(ReefAutoAlign.AlignmentResult result) {
+        alignmentResult = Optional.ofNullable(result);
+    }
+
+    public void clearAlignmentResult() {
+        alignmentResult = Optional.empty();
+    }
+
+    public void setAutoAlignActive(boolean active) {
+        autoAlignActive = active;
+    }
+
+    public void handleDisabledInit() {
+        autoAlignActive = false;
+        celebrationEndTimestamp = -1.0;
+        climbSettledDuringMode = false;
+        lastAppliedPattern = null;
+        ledHandler.setDisabledAnimation(true);
+    }
+
+    public void update() {
+        double now = Timer.getFPGATimestamp();
+        RobotSupervisor.Mode currentMode = supervisor.getMode();
+        if (currentMode == RobotSupervisor.Mode.CLIMB && subsystemManager.isTargetSettled()) {
+            climbSettledDuringMode = true;
+        }
+
+        if (lastMode == RobotSupervisor.Mode.CLIMB && currentMode != RobotSupervisor.Mode.CLIMB) {
+            if (climbSettledDuringMode) {
+                celebrationEndTimestamp = now + Constants.LEDs.CELEBRATION_DURATION_SECONDS;
+            }
+            climbSettledDuringMode = false;
+        }
+        lastMode = currentMode;
+
+        boolean disabled = DriverStation.isDisabled();
+        ledHandler.setDisabledAnimation(disabled);
+        if (disabled) {
+            lastAppliedPattern = null;
+            ledHandler.clearPattern();
+            return;
+        }
+
+        PatternCandidate selection = selectPattern(now, currentMode);
+        LedPattern selected = selection != null ? selection.pattern() : null;
+        if (!Objects.equals(selected, lastAppliedPattern)) {
+            ledHandler.setPattern(selected);
+            lastAppliedPattern = selected;
+        }
+
+        String reason = selection != null ? selection.reason() : "None";
+        Logger.recordOutput("LEDs/ActivePattern", selected != null ? selected.style().name() : "OFF");
+        Logger.recordOutput("LEDs/ActiveReason", reason);
+        Logger.recordOutput("LEDs/ActivePriority", selected != null ? selected.priority() : -1);
+        Logger.recordOutput(
+                "LEDs/ActivePrimaryRGB",
+                selected != null ? selected.primary().toArray() : LedColor.BLACK.toArray()
+        );
+        Logger.recordOutput("LEDs/AutoAlignActive", autoAlignActive);
+    }
+
+    private PatternCandidate selectPattern(double now, RobotSupervisor.Mode mode) {
+        List<PatternCandidate> candidates = new ArrayList<>();
+        GamePieceState pieces = supervisor.getPieceState();
+        boolean coralInManipulator = pieces.isCoralInWrist();
+        boolean algaeInEndEffector = pieces.isAlgaeInEndEffector();
+        boolean targetSettled = subsystemManager.isTargetSettled();
+        boolean climbConstraintsActive = supervisor.lastRequestUsedClimbMode();
+        boolean algaeMode = supervisor.isAlgaeMode();
+
+        if (celebrationEndTimestamp > 0.0 && now < celebrationEndTimestamp) {
+            candidates.add(
+                    new PatternCandidate(
+                            LedPattern.alternating(
+                                    100,
+                                    Constants.LEDs.DEEP_GREEN,
+                                    Constants.LEDs.YELLOW,
+                                    Constants.LEDs.CELEBRATION_PERIOD_SECONDS
+                            ),
+                            "ClimbCelebration"
+                    )
+            );
+        }
+
+        if (mode == RobotSupervisor.Mode.CLIMB || climbConstraintsActive) {
+            if (targetSettled) {
+                candidates.add(
+                        new PatternCandidate(
+                                LedPattern.solid(90, Constants.LEDs.DEEP_GREEN),
+                                "ClimbStable"
+                        )
+                );
+            } else {
+                candidates.add(
+                        new PatternCandidate(
+                                LedPattern.flashing(95, Constants.LEDs.DEEP_GREEN, FLASH_PERIOD),
+                                "ClimbAttempt"
+                        )
+                );
+            }
+        }
+
+        if (algaeInEndEffector) {
+            candidates.add(
+                    new PatternCandidate(
+                            LedPattern.flashing(80, Constants.LEDs.TEAL, FLASH_PERIOD),
+                            "AlgaeInEndEffector"
+                    )
+            );
+        } else if (mode == RobotSupervisor.Mode.ALGAE || algaeMode) {
+            candidates.add(
+                    new PatternCandidate(
+                            LedPattern.solid(70, Constants.LEDs.TEAL),
+                            "AlgaeMode"
+                    )
+            );
+        }
+
+        if (mode == RobotSupervisor.Mode.CORAL && coralInManipulator) {
+            alignmentResult.ifPresent(result -> {
+                boolean oddSector = (result.sectorIndex() % 2) == 1;
+                LedColor branchColor = oddSector ? Constants.LEDs.YELLOW : Constants.LEDs.PURPLE;
+                if (autoAlignActive) {
+                    candidates.add(
+                            new PatternCandidate(
+                                    LedPattern.flashing(60, branchColor, FLASH_PERIOD),
+                                    "AutoAlignBranch"
+                            )
+                    );
+                } else {
+                    candidates.add(
+                            new PatternCandidate(
+                                    LedPattern.solid(50, branchColor),
+                                    "BranchSector"
+                            )
+                    );
+                }
+            });
+        }
+
+        if (mode == RobotSupervisor.Mode.CORAL) {
+            candidates.add(
+                    new PatternCandidate(
+                            LedPattern.solid(40, Constants.LEDs.LIGHT_GREEN),
+                            "CoralMode"
+                    )
+            );
+        }
+
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        return candidates.stream()
+                .max(Comparator.comparingInt(candidate -> candidate.pattern().priority()))
+                .orElse(null);
+    }
+
+    private record PatternCandidate(LedPattern pattern, String reason) {}
+}

--- a/src/main/java/frc/robot/led/LedPattern.java
+++ b/src/main/java/frc/robot/led/LedPattern.java
@@ -1,0 +1,46 @@
+package frc.robot.led;
+
+import java.util.Objects;
+
+/**
+ * Describes a prioritized LED pattern request.
+ */
+public record LedPattern(
+        int priority,
+        Style style,
+        LedColor primary,
+        LedColor secondary,
+        double periodSeconds
+) {
+    private static final double DEFAULT_PERIOD_SECONDS = 0.5;
+
+    public enum Style {
+        SOLID,
+        FLASHING,
+        ALTERNATING
+    }
+
+    public LedPattern {
+        Objects.requireNonNull(style, "style");
+        Objects.requireNonNull(primary, "primary");
+        Objects.requireNonNull(secondary, "secondary");
+        if (priority < 0) {
+            priority = 0;
+        }
+        if (periodSeconds <= 0.0 && style != Style.SOLID) {
+            periodSeconds = DEFAULT_PERIOD_SECONDS;
+        }
+    }
+
+    public static LedPattern solid(int priority, LedColor color) {
+        return new LedPattern(priority, Style.SOLID, color, color, 0.0);
+    }
+
+    public static LedPattern flashing(int priority, LedColor color, double periodSeconds) {
+        return new LedPattern(priority, Style.FLASHING, color, LedColor.BLACK, periodSeconds);
+    }
+
+    public static LedPattern alternating(int priority, LedColor first, LedColor second, double periodSeconds) {
+        return new LedPattern(priority, Style.ALTERNATING, first, second, periodSeconds);
+    }
+}

--- a/src/main/java/frc/robot/subsystems/LEDHandler.java
+++ b/src/main/java/frc/robot/subsystems/LEDHandler.java
@@ -1,118 +1,136 @@
 package frc.robot.subsystems;
 
-import java.util.HashMap;
+import java.util.Objects;
 
-import com.ctre.phoenix.led.Animation;
+import org.littletonrobotics.junction.Logger;
+
 import com.ctre.phoenix.led.CANdle;
 import com.ctre.phoenix.led.CANdle.LEDStripType;
 import com.ctre.phoenix.led.CANdle.VBatOutputMode;
 import com.ctre.phoenix.led.CANdleConfiguration;
-import com.ctre.phoenix.led.ColorFlowAnimation;
-import com.ctre.phoenix.led.LarsonAnimation;
 import com.ctre.phoenix.led.RainbowAnimation;
-import com.ctre.phoenix.led.StrobeAnimation;
 
-import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants;
-import frc.robot.Constants.LEDs;
+import frc.robot.led.LedColor;
+import frc.robot.led.LedPattern;
 
+/**
+ * Thin wrapper around the CTRE CANdle LED controller.
+ */
 public class LEDHandler extends SubsystemBase {
-
     private final CANdle candle;
-    private final CANdleConfiguration config;
+    private final boolean hasHardware;
+    private final int ledCount;
 
-    private final int LEDCount;
+    private LedPattern activePattern;
+    private LedColor lastAppliedColor;
+    private boolean toggleState = true;
+    private double lastToggleTimestamp = 0.0;
+    private boolean disabledAnimationActive = false;
 
-    private HashMap<String, int[]> colorDatabase = new HashMap<String, int[]>();
-
-    public LEDHandler(int deviceID, int LEDCount) {
-
-        this.LEDCount = LEDCount;
-
-        candle = new CANdle(deviceID);
-        config = new CANdleConfiguration();
-
-        config.statusLedOffWhenActive = true;
-        config.disableWhenLOS = false;
-        config.stripType = LEDStripType.GRB;
-        config.brightnessScalar = 0.5;
-        config.vBatOutputMode = VBatOutputMode.Modulated;
-        candle.configAllSettings(config, 100);
-
-
-        colorDatabase.put("Red", new int[] {255, 0, 0});
-        colorDatabase.put("Green", new int[] {0, 255, 0});
-        colorDatabase.put("Blue", new int[] {0, 0, 255});
-        colorDatabase.put("Yellow", new int[] {255, 255, 0});
-        colorDatabase.put("Purple", new int[] {255, 0, 255});
-        colorDatabase.put("Cyan", new int[] {0, 255, 255});
-        colorDatabase.put("White", new int[] {255, 255, 255});
-        colorDatabase.put("noColor", new int[] {0, 0, 0});
+    public LEDHandler(int deviceID, int ledCount) {
+        this.ledCount = ledCount;
+        if (RobotBase.isReal()) {
+            candle = new CANdle(deviceID);
+            CANdleConfiguration config = new CANdleConfiguration();
+            config.statusLedOffWhenActive = true;
+            config.disableWhenLOS = false;
+            config.stripType = LEDStripType.GRB;
+            config.brightnessScalar = 0.5;
+            config.vBatOutputMode = VBatOutputMode.Modulated;
+            candle.configAllSettings(config, 100);
+            hasHardware = true;
+        } else {
+            candle = null;
+            hasHardware = false;
+        }
     }
 
-
-    public void setStaticColorFullStrip(int r, int g, int b) {
-        candle.setLEDs(r, g, b);
+    public void setPattern(LedPattern pattern) {
+        activePattern = pattern;
+        toggleState = true;
+        lastToggleTimestamp = Timer.getFPGATimestamp();
+        if (!disabledAnimationActive) {
+            if (pattern == null) {
+                applyColor(LedColor.BLACK);
+            } else {
+                applyColor(pattern.primary());
+            }
+        }
     }
 
-    public void setStaticColor(int r, int g, int b, int startIndex, int count) {
-        candle.setLEDs(r, g, b, 0, startIndex, count);
+    public void clearPattern() {
+        setPattern(null);
     }
 
-    public void applyAnimation(Animation animation) {
-        candle.animate(animation);
+    public void setDisabledAnimation(boolean enabled) {
+        if (enabled && !disabledAnimationActive) {
+            disabledAnimationActive = true;
+            lastAppliedColor = null;
+            if (hasHardware) {
+                candle.animate(new RainbowAnimation(0.5, 0.5, ledCount));
+            }
+        } else if (!enabled && disabledAnimationActive) {
+            disabledAnimationActive = false;
+            if (hasHardware) {
+                candle.clearAnimation(0);
+            }
+            if (activePattern == null) {
+                applyColor(LedColor.BLACK);
+            } else {
+                applyColor(activePattern.primary());
+            }
+        }
     }
 
-    public void startRainbowAnimation(double brightness, double speed, int numLeds) {
-        Animation rainbowAnimation = new RainbowAnimation(brightness, speed, numLeds);
-        applyAnimation(rainbowAnimation);
-    }
-
-    public void startLarsonAnimation(int r, int g, int b, double speed, int numLeds, LarsonAnimation.BounceMode mode, int size) {
-        Animation larsonAnimation = new LarsonAnimation(r, g, b, 0, speed, numLeds, mode, size);
-        applyAnimation(larsonAnimation);
-    }
-
-    public void startStrobeAnimation(int r, int g, int b, double speed, int numLeds) {
-        Animation strobeAnimation = new StrobeAnimation(r, g, b, 0, speed, numLeds);
-        applyAnimation(strobeAnimation);
-    }
-
-    public void startColorFlowAnimation(int r, int g, int b, double speed, int numLeds) {
-        Animation ColorFlowAnimation = new StrobeAnimation(r, g, b, 0, speed, numLeds);
-        applyAnimation(ColorFlowAnimation);
-    }
-
-    public void chooseAnimation(String requestedAnimation, int r, int g, int b, double speed) {
-
-        switch(requestedAnimation) {
-            case "Rainbow":
-                applyAnimation(new RainbowAnimation(config.brightnessScalar, speed, LEDCount));
-                break;
-            case "Larson":
-                applyAnimation(new LarsonAnimation(r, g, b, 0, speed, LEDCount, LarsonAnimation.BounceMode.Center, LEDCount / 3)); //TODO completley random might look bad so fix
-                break;
-            case "Strobe":
-                applyAnimation(new StrobeAnimation(r, g, b, 0, speed, LEDCount));
-                break;
-            case "ColorFlow":
-                applyAnimation(new StrobeAnimation(r, g, b, 0, speed, LEDCount));
-                break;
-            default:
-                break;
+    @Override
+    public void periodic() {
+        if (disabledAnimationActive) {
+            return;
         }
 
+        if (activePattern == null) {
+            applyColor(LedColor.BLACK);
+            return;
+        }
+
+        if (activePattern.style() == LedPattern.Style.SOLID) {
+            applyColor(activePattern.primary());
+            return;
+        }
+
+        double period = activePattern.periodSeconds();
+        if (period <= 0.0) {
+            period = 0.5;
+        }
+        double now = Timer.getFPGATimestamp();
+        if ((now - lastToggleTimestamp) >= (period / 2.0)) {
+            toggleState = !toggleState;
+            lastToggleTimestamp = now;
+        }
+
+        LedColor color;
+        if (activePattern.style() == LedPattern.Style.FLASHING) {
+            color = toggleState ? activePattern.primary() : LedColor.BLACK;
+        } else {
+            color = toggleState ? activePattern.primary() : activePattern.secondary();
+        }
+        applyColor(color);
     }
 
-     public void updateFieldSetupLEDs() {
-        // Set Mechanism Status LEDs
-    
-        // Set combined status LE
-        // Set Connection Status LEDs
-        candle.setLEDs(DriverStation.isDSAttached() ? 0 : 255, DriverStation.isDSAttached() ? 255 : 0, 0, 0, 1, 1);
-        candle.setLEDs(DriverStation.isFMSAttached() ? 0 : 255, DriverStation.isFMSAttached() ? 255 : 0, 0, 0, 2, 1);
-        
-    }
+    private void applyColor(LedColor color) {
+        Objects.requireNonNull(color, "color");
+        if (lastAppliedColor != null && lastAppliedColor.equals(color)) {
+            return;
+        }
 
+        if (hasHardware) {
+            int[] rgb = color.toArray();
+            candle.setLEDs(rgb[0], rgb[1], rgb[2]);
+        }
+        lastAppliedColor = color;
+        Logger.recordOutput("LEDs/RGB", new int[] {color.r(), color.g(), color.b()});
+    }
 }


### PR DESCRIPTION
## Summary
- track climb completion before triggering celebration animations and reset internal state when disabled
- gate sector colors on coral possession, fold algae/climb checks into prioritized candidates, and log the reason for the chosen LED pattern
- publish the active LED color, priority, and auto-align flag through AdvantageKit for easier diagnostics
- avoid resetting the applied CANdle pattern when the selected animation doesn't change so flashing and alternating cues progress normally

## Testing
- ./gradlew build -x test

------
https://chatgpt.com/codex/tasks/task_e_68eb0f12db688323b8cdb52694f13115